### PR TITLE
build symbolic-cabi as lib

### DIFF
--- a/symbolic-cabi/Cargo.toml
+++ b/symbolic-cabi/Cargo.toml
@@ -17,7 +17,7 @@ edition = "2021"
 publish = false
 
 [lib]
-crate-type = ["cdylib"]
+crate-type = ["cdylib", "lib"] # lib is required for us to build symbolic in dd-source
 
 [dependencies]
 proguard = { workspace = true, features = ["uuid"] }


### PR DESCRIPTION
dd-source has a `symbolic-ffi` Rust wrapper.
we build `symbolic-cabi` as a lib so that it can link to the `symbolic-ffi`, otherwise `cdylib` cannot be linked against Rust binaries apparently.