### PR TITLE
Buranmert/rum 17563 proguardcache borrow bytes

### DIFF
--- a/symbolic-cabi/src/proguard.rs
+++ b/symbolic-cabi/src/proguard.rs
@@ -250,14 +250,21 @@ ffi_fn! {
 }
 
 ffi_fn! {
-    /// Parses a ProguardCache from its binary representation.
+    /// Parses a ProguardCache from its binary representation without taking
+    /// ownership of the pointer.
+    ///
+    /// The cache borrows `bytes` for its entire lifetime; it is not copied. The
+    /// caller must keep the buffer alive and at a fixed address until the cache
+    /// is released with `symbolic_proguardcache_free`. This mirrors
+    /// `symbolic_symcache_from_bytes`.
     unsafe fn symbolic_proguardcache_open(
         bytes: *const u8,
         len: usize,
     ) -> Result<*mut SymbolicProguardCache> {
-        let byteview = ByteView::from_vec(std::slice::from_raw_parts(bytes, len).to_vec());
+        let byteview = ByteView::from_slice(std::slice::from_raw_parts(bytes, len));
         let inner = SelfCell::try_new(byteview, |data| {
-            // SAFETY: data points into the ByteView we just created.
+            // SAFETY: data points into the ByteView we just created, which
+            // borrows the caller's buffer.
             ProguardCache::parse(unsafe { &*data })
                 .map_err(|e| Box::new(e) as Box<dyn std::error::Error + 'static>)
                 .map(|cache| CacheInner { cache })


### PR DESCRIPTION
## Summary

Hotfix on top of the `12.17.5-dd` tag — **not** intended to merge into `master` directly, since `master` is several releases behind this fork's tag history. This targets the `hotfix/12.17.5-dd` branch (created from the `12.17.5-dd` tag) instead.

**Change:**

`symbolic_proguardcache_open` no longer copies the input bytes (`symbolic-cabi/src/proguard.rs`) — switched from `ByteView::from_vec(...to_vec())` to `ByteView::from_slice(...)`, so the cache now borrows the caller-provided buffer instead of copying it. This mirrors `symbolic_symcache_from_bytes`'s existing borrowing behavior. The caller must keep the buffer alive and at a fixed address until the cache is freed with `symbolic_proguardcache_free` — documented in the updated doc comment.

## Test plan

- [x] `cargo build -p symbolic-cabi` succeeds
- [x] `cargo test -p symbolic-cabi` passes
